### PR TITLE
Fix build issues on gcc-10

### DIFF
--- a/saiasiccmp/SaiSwitchAsic.h
+++ b/saiasiccmp/SaiSwitchAsic.h
@@ -3,6 +3,7 @@
 #include "syncd/SaiSwitchInterface.h"
 
 #include <map>
+#include <string>
 
 namespace saiasiccmp
 {

--- a/unittest/vslib/TestTrafficForwarder.cpp
+++ b/unittest/vslib/TestTrafficForwarder.cpp
@@ -44,7 +44,7 @@ TEST(TrafficForwarder, addVlanTag)
 
     EXPECT_FALSE(TrafficForwarder::addVlanTag(buffer, length, hdr));
 
-    struct tpacket_auxdata* aux = (struct tpacket_auxdata*)CMSG_DATA(cmsg);
+    struct tpacket_auxdata* aux = (struct tpacket_auxdata*)(void*)CMSG_DATA(cmsg);
 
     // https://en.wikipedia.org/wiki/IEEE_802.1Q
     //


### PR DESCRIPTION
Fixes 998 (link when community PR is created)

This includes two fixes. One for an issue where the string library must be explicitly imported. The solution was taken directly from the gcc-10 error message.

```
In file included from SaiSwitchAsic.cpp:1:
SaiSwitchAsic.h:24:46: error: 'string' is not a member of 'std'
   24 |                     _In_ const std::map<std::string, sai_object_id_t>& hidden,
      |                                              ^~~~~~
SaiSwitchAsic.h:4:1: note: 'std::string' is defined in header '<string>'; did you forget to '#include <string>'?
    3 | #include "syncd/SaiSwitchInterface.h"
  +++ |+#include <string>
    4 |
```

The other fix is due to a cast-align warning introduced by gcc-10. This was fixed in another location in the code by https://github.com/Azure/sonic-sairedis/pull/894

I mirrored this same exact fix in the unit test file so that the code is aligned. 

I feel it necessary to warn that casting to void* is a very obfuscated way around this warning and in general tends to attract bugs, however I will leave this to the maintainers to fix if they wish as there was already a discussion of this in the original PR. 